### PR TITLE
fix(readme): @types/node is now a dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ console.log(postController);
 
 3. You may need to install node typings:
 
-    `npm install @types/node --save`
+    `npm install @types/node --save-dev`
 
 
 4. Enabled following settings in `tsconfig.json`:


### PR DESCRIPTION
The correct way to install typings in any project is to save 'em as dev dependencies so that it possibly isn't included in production installs.