### PR TITLE
Service functions can be injected in class constructors by reference

### DIFF
--- a/src/Container.ts
+++ b/src/Container.ts
@@ -4,6 +4,7 @@ import {Handler} from "./types/Handler";
 import {ObjectType} from "./types/ObjectType";
 import {ServiceIdentifier} from "./types/ServiceIdentifier";
 import {ServiceMetadata} from "./types/ServiceMetadata";
+import { ServiceDefinition } from "./types/ServiceDefinition";
 
 /**
  * Service container.
@@ -97,7 +98,7 @@ export class Container {
      * Retrieves the service with given name or type from the service container.
      * Optionally, parameters can be passed in case if instance is initialized in the container for the first time.
      */
-    static get<T>(service: { service: T }): T;
+    static get<T>(service: ServiceDefinition<T>): T;
 
     /**
      * Retrieves the service with given name or type from the service container.

--- a/src/ContainerInstance.ts
+++ b/src/ContainerInstance.ts
@@ -5,6 +5,7 @@ import {Token} from "./Token";
 import {ObjectType} from "./types/ObjectType";
 import {ServiceIdentifier} from "./types/ServiceIdentifier";
 import {ServiceMetadata} from "./types/ServiceMetadata";
+import { ServiceDefinition } from "./types/ServiceDefinition";
 
 /**
  * TypeDI can have multiple containers.
@@ -90,7 +91,7 @@ export class ContainerInstance {
      * Retrieves the service with given name or type from the service container.
      * Optionally, parameters can be passed in case if instance is initialized in the container for the first time.
      */
-    get<T>(id: { service: T }): T;
+    get<T>(id: ServiceDefinition<T>): T;
 
     /**
      * Retrieves the service with given name or type from the service container.
@@ -180,8 +181,8 @@ export class ContainerInstance {
         if (typeof identifierOrServiceMetadata === "string" || identifierOrServiceMetadata instanceof Token) {
             return this.set({ id: identifierOrServiceMetadata, value: value });
         }
-        if (typeof identifierOrServiceMetadata === "object" && (identifierOrServiceMetadata as { service: Token<any> }).service) {
-            return this.set({ id: (identifierOrServiceMetadata as { service: Token<any> }).service, value: value });
+        if (typeof identifierOrServiceMetadata === "object" && (identifierOrServiceMetadata as ServiceDefinition<Token<any>>).service) {
+            return this.set({ id: (identifierOrServiceMetadata as ServiceDefinition<Token<any>>).service, value: value });
         }
         if (identifierOrServiceMetadata instanceof Function) {
             return this.set({ type: identifierOrServiceMetadata, id: identifierOrServiceMetadata, value: value });
@@ -287,8 +288,8 @@ export class ContainerInstance {
         } else if (identifier instanceof Function) {
             type = identifier;
 
-        // } else if (identifier instanceof Object && (identifier as { service: Token<any> }).service instanceof Token) {
-        //     type = (identifier as { service: Token<any> }).service;
+        // } else if (identifier instanceof Object && (identifier as ServiceDefinition<Token<any>>).service instanceof Token) {
+        //     type = (identifier as ServiceDefinition<Token<any>>).service;
         }
 
         // if service was not found then create a new one and register it

--- a/src/decorators/Inject.ts
+++ b/src/decorators/Inject.ts
@@ -1,6 +1,7 @@
 import {Container} from "../Container";
 import {Token} from "../Token";
 import {CannotInjectError} from "../error/CannotInjectError";
+import {ServiceDefinition} from "../types/ServiceDefinition";
 
 /**
  * Injects a service into a class property or constructor parameter.
@@ -20,7 +21,7 @@ export function Inject(token: Token<any>): Function;
 /**
  * Injects a service into a class property or constructor parameter.
  */
-export function Inject(typeOrName?: ((type?: any) => Function)|string|Token<any>): Function {
+export function Inject(typeOrName?: ((type?: any) => Function)|string|Token<any>|ServiceDefinition<any>): Function {
     return function(target: Object, propertyName: string, index?: number) {
 
         if (!typeOrName)
@@ -38,8 +39,12 @@ export function Inject(typeOrName?: ((type?: any) => Function)|string|Token<any>
                 } else if (typeOrName instanceof Token) {
                     identifier = typeOrName;
 
-                } else {
+                } else if (typeOrName instanceof Function) {
                     identifier = typeOrName();
+
+                } else {
+                    identifier = typeOrName.service;
+
                 }
 
                 if (identifier === Object)

--- a/src/decorators/Service.ts
+++ b/src/decorators/Service.ts
@@ -3,53 +3,54 @@ import {ContainerInstance} from "../ContainerInstance";
 import {Token} from "../Token";
 import {ServiceMetadata} from "../types/ServiceMetadata";
 import {ServiceOptions} from "../types/ServiceOptions";
+import {ServiceDefinition} from "../types/ServiceDefinition";
+import {ObjectType} from "../types/ObjectType";
 
-
-export type ObjectType<T1> = { new (...args: any[]): T1 } | { service: T1 };
+export type Dependency<T1> = ObjectType<T1> | ServiceDefinition<T1>;
 
 export function Service<R>(
     factory: () => R
-): { service: R };
+): ServiceDefinition<R>;
 export function Service<R, T1>(
-    dependencies: [ObjectType<T1>],
+    dependencies: [Dependency<T1>],
     factory: (dependency1: T1) => R
-): { service: R };
+): ServiceDefinition<R>;
 export function Service<R, T1, T2>(
-    dependencies: [ObjectType<T1>, ObjectType<T2>],
+    dependencies: [Dependency<T1>, Dependency<T2>],
     factory: (dependency1: T1, dependency2: T2) => R
-): { service: R };
+): ServiceDefinition<R>;
 export function Service<R, T1, T2, T3>(
-    dependencies: [ObjectType<T1>, ObjectType<T2>, ObjectType<T3>],
+    dependencies: [Dependency<T1>, Dependency<T2>, Dependency<T3>],
     factory: (dependency1: T1, dependency2: T2, dependency3: T3) => R
-): { service: R };
+): ServiceDefinition<R>;
 export function Service<R, T1, T2, T3, T4>(
-    dependencies: [ObjectType<T1>, ObjectType<T2>, ObjectType<T3>, ObjectType<T4>],
+    dependencies: [Dependency<T1>, Dependency<T2>, Dependency<T3>, Dependency<T4>],
     factory: (dependency1: T1, dependency2: T2, dependency3: T3, dependency4: T4) => R
-): { service: R };
+): ServiceDefinition<R>;
 export function Service<R, T1, T2, T3, T4, T5>(
-    dependencies: [ObjectType<T1>, ObjectType<T2>, ObjectType<T3>, ObjectType<T4>, ObjectType<T5>],
+    dependencies: [Dependency<T1>, Dependency<T2>, Dependency<T3>, Dependency<T4>, Dependency<T5>],
     factory: (dependency1: T1, dependency2: T2, dependency3: T3, dependency4: T4, dependency5: T5) => R
-): { service: R };
+): ServiceDefinition<R>;
 export function Service<R, T1, T2, T3, T4, T5, T6>(
-    dependencies: [ObjectType<T1>, ObjectType<T2>, ObjectType<T3>, ObjectType<T4>, ObjectType<T5>, ObjectType<T6>],
+    dependencies: [Dependency<T1>, Dependency<T2>, Dependency<T3>, Dependency<T4>, Dependency<T5>, Dependency<T6>],
     factory: (dependency1: T1, dependency2: T2, dependency3: T3, dependency4: T4, dependency5: T5, dependency6: T6) => R
-): { service: R };
+): ServiceDefinition<R>;
 export function Service<R, T1, T2, T3, T4, T5, T6, T7>(
-    dependencies: [ObjectType<T1>, ObjectType<T2>, ObjectType<T3>, ObjectType<T4>, ObjectType<T5>, ObjectType<T6>, ObjectType<T7>],
+    dependencies: [Dependency<T1>, Dependency<T2>, Dependency<T3>, Dependency<T4>, Dependency<T5>, Dependency<T6>, Dependency<T7>],
     factory: (dependency1: T1, dependency2: T2, dependency3: T3, dependency4: T4, dependency5: T5, dependency6: T6, dependency7: T7) => R
-): { service: R };
+): ServiceDefinition<R>;
 export function Service<R, T1, T2, T3, T4, T5, T6, T7, T8>(
-    dependencies: [ObjectType<T1>, ObjectType<T2>, ObjectType<T3>, ObjectType<T4>, ObjectType<T5>, ObjectType<T6>, ObjectType<T7>, ObjectType<T8>],
+    dependencies: [Dependency<T1>, Dependency<T2>, Dependency<T3>, Dependency<T4>, Dependency<T5>, Dependency<T6>, Dependency<T7>, Dependency<T8>],
     factory: (dependency1: T1, dependency2: T2, dependency3: T3, dependency4: T4, dependency5: T5, dependency6: T6, dependency7: T7, dependency8: T8) => R
-): { service: R };
+): ServiceDefinition<R>;
 export function Service<R, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
-    dependencies: [ObjectType<T1>, ObjectType<T2>, ObjectType<T3>, ObjectType<T4>, ObjectType<T5>, ObjectType<T6>, ObjectType<T7>, ObjectType<T8>, ObjectType<T9>],
+    dependencies: [Dependency<T1>, Dependency<T2>, Dependency<T3>, Dependency<T4>, Dependency<T5>, Dependency<T6>, Dependency<T7>, Dependency<T8>, Dependency<T9>],
     factory: (dependency1: T1, dependency2: T2, dependency3: T3, dependency4: T4, dependency5: T5, dependency6: T6, dependency7: T7, dependency8: T8, dependency9: T9) => R
-): { service: R };
+): ServiceDefinition<R>;
 export function Service<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
-    dependencies: [ObjectType<T1>, ObjectType<T2>, ObjectType<T3>, ObjectType<T4>, ObjectType<T5>, ObjectType<T6>, ObjectType<T7>, ObjectType<T8>, ObjectType<T9>, ObjectType<T10>],
+    dependencies: [Dependency<T1>, Dependency<T2>, Dependency<T3>, Dependency<T4>, Dependency<T5>, Dependency<T6>, Dependency<T7>, Dependency<T8>, Dependency<T9>, Dependency<T10>],
     factory: (dependency1: T1, dependency2: T2, dependency3: T3, dependency4: T4, dependency5: T5, dependency6: T6, dependency7: T7, dependency8: T8, dependency9: T9, dependency10: T10) => R
-): { service: R };
+): ServiceDefinition<R>;
 
 /**
  * Marks class as a service that can be injected using Container.

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export {Handler} from "./types/Handler";
 export {ServiceOptions} from "./types/ServiceOptions";
 export {ServiceIdentifier} from "./types/ServiceIdentifier";
 export {ServiceMetadata} from "./types/ServiceMetadata";
+export {ServiceDefinition} from "./types/ServiceDefinition";
 export {ObjectType} from "./types/ObjectType";
 
 export default Container;

--- a/src/types/ServiceDefinition.ts
+++ b/src/types/ServiceDefinition.ts
@@ -1,0 +1,6 @@
+/**
+ * Special type that defines the value of a dependency created by the Service function
+ */
+export interface ServiceDefinition<T> {
+  service: T
+}

--- a/src/types/ServiceIdentifier.ts
+++ b/src/types/ServiceIdentifier.ts
@@ -1,7 +1,8 @@
 import {Token} from "../Token";
+import {ServiceDefinition} from "./ServiceDefinition";
 
 /**
  * Unique service identifier.
  * Can be some class type, or string id, or instance of Token.
  */
-export type ServiceIdentifier<T = any> = Function|Token<T>|string|{ service: T };
+export type ServiceIdentifier<T = any> = Function|Token<T>|string|ServiceDefinition<T>;


### PR DESCRIPTION
- Provided type definition for services created by Service function
- Allowed use of ServiceDefinition in @Inject to be used similarly to Tokens
- Service functions can be injected by reference into @Service-annotated class constructors