### PR TITLE
fix: prevent maximum call stack error when creating scoped containers with circular dependencies

### DIFF
--- a/src/Container.ts
+++ b/src/Container.ts
@@ -43,6 +43,10 @@ export class Container {
         let container = this.instances.find(instance => instance.id === instanceId);
         if (!container) {
             container = new ContainerInstance(instanceId);
+            container.services.push(...this.globalInstance.services.map(s => ({
+                ...s,
+                value: s.global ? s.value : undefined
+            })));
             this.instances.push(container);
         }
 

--- a/src/ContainerInstance.ts
+++ b/src/ContainerInstance.ts
@@ -28,7 +28,7 @@ export class ContainerInstance {
     /**
      * All registered services.
      */
-    private services: ServiceMetadata<any, any>[] = [];
+    public services: ServiceMetadata<any, any>[] = [];
 
     // -------------------------------------------------------------------------
     // Constructor
@@ -287,8 +287,8 @@ export class ContainerInstance {
         } else if (identifier instanceof Function) {
             type = identifier;
 
-        // } else if (identifier instanceof Object && (identifier as { service: Token<any> }).service instanceof Token) {
-        //     type = (identifier as { service: Token<any> }).service;
+            // } else if (identifier instanceof Object && (identifier as { service: Token<any> }).service instanceof Token) {
+            //     type = (identifier as { service: Token<any> }).service;
         }
 
         // if service was not found then create a new one and register it

--- a/test/github-issues/112/issue-112.spec.ts
+++ b/test/github-issues/112/issue-112.spec.ts
@@ -1,0 +1,40 @@
+import "reflect-metadata";
+import {Container} from "../../../src/Container";
+import {Service} from "../../../src/decorators/Service";
+import {Inject} from "../../../src";
+
+describe("github issues > #112 Circular dependencies inside a scoped container", function() {
+
+    beforeEach(() => Container.reset());
+
+    it("should work properly", function() {
+
+        @Service()
+        class A {
+            @Inject(() => B) public b: any;
+        }
+
+        @Service()
+        class B {
+            @Inject(() => A) public a: any;
+        }
+
+        const aFromGlobal = Container.get(A);
+        const bFromGlobal = Container.get(B);
+
+        aFromGlobal.should.be.equal(bFromGlobal.a);
+        bFromGlobal.should.be.equal(aFromGlobal.b);
+
+        const scopedContainer = Container.of("foo");
+
+        const aFromScoped = scopedContainer.get(A);
+        const bFromScoped = scopedContainer.get(B);
+
+        aFromScoped.should.be.equal(bFromScoped.a);
+        bFromScoped.should.be.equal(aFromScoped.b);
+
+        aFromScoped.should.not.be.equal(aFromGlobal);
+        bFromScoped.should.not.be.equal(bFromGlobal);
+    });
+
+});


### PR DESCRIPTION
### Description

This PR fixes the issue mentioned in #112 by copying services to a scoped container at the time of creation, instead of relying on them being cloned from the global container when `get` is called.

The `ContainerInstance.services` property has been made public, so it can be modified when a new scoped container is created. This could probably be moved into the constructor.

fixes #112