### PR TITLE
fix: Constructor injection throw error if @Inject has no parameter

### DIFF
--- a/src/decorators/Inject.ts
+++ b/src/decorators/Inject.ts
@@ -22,7 +22,15 @@ export function Inject(token: Token<any>): Function;
  */
 export function Inject(typeOrName?: ((type?: any) => Function) | string | Token<any>): Function {
   return function (target: Object, propertyName: string, index?: number) {
-    if (!typeOrName) typeOrName = () => (Reflect as any).getMetadata('design:type', target, propertyName);
+    if (!typeOrName) {
+      if (propertyName === undefined) {
+        // constructor injection
+        typeOrName = () => (Reflect as any).getMetadata('design:paramtypes', target, undefined)[index as number];
+      } else {
+        // property injection
+        typeOrName = () => (Reflect as any).getMetadata('design:type', target, propertyName);
+      }
+    }
 
     Container.registerHandler({
       object: target,

--- a/test/decorators/Inject.spec.ts
+++ b/test/decorators/Inject.spec.ts
@@ -52,16 +52,20 @@ describe('Inject Decorator', function () {
     @Service('mega.service')
     class NamedService {}
     @Service()
+    class ParameterlessInjectService {}
+    @Service()
     class TestServiceWithParameters {
       constructor(
         public testClass: TestService,
         @Inject(type => SecondTestService) public secondTest: any,
-        @Inject('mega.service') public megaService: any
+        @Inject('mega.service') public megaService: any,
+        @Inject() public parameterlessInject: ParameterlessInjectService
       ) {}
     }
     expect(Container.get(TestServiceWithParameters).testClass).toBeInstanceOf(TestService);
     expect(Container.get(TestServiceWithParameters).secondTest).toBeInstanceOf(SecondTestService);
     expect(Container.get(TestServiceWithParameters).megaService).toBeInstanceOf(NamedService);
+    expect(Container.get(TestServiceWithParameters).parameterlessInject).toBeInstanceOf(ParameterlessInjectService);
   });
 
   it("should inject service should work with 'many' instances", function () {


### PR DESCRIPTION
## Description
<!-- A clear and concise description what these changes does. -->
Constructor injection will throw error, if @Inject() has no parameter specified. 
This change will get constructor parameter type for default @Inject type.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

### Fixes
<!-- If there is no issue being resolved, open one before creating this pull request. -->
<!-- If the PR doesn't fully resolve the issue, replace 'fixes' with 'references'. -->
fixes #[issue number], fixes #[issue number]
