### PR TITLE
perf: replace array with map

### DIFF
--- a/test/Container.spec.ts
+++ b/test/Container.spec.ts
@@ -379,4 +379,40 @@ describe('Container', function () {
       expect(() => Container.get(MyService)).toThrowError(ServiceNotFoundError);
     });
   });
+
+  describe('has', function () {
+    it('should has true', function () {
+      class TestService {
+        constructor(public name: string) {}
+      }
+      const testService = new TestService('this is test');
+      Container.set(TestService, testService);
+      expect(Container.has(TestService)).toBe(true);
+    });
+  });
+
+  describe('getMany', function () {
+    it('should getMany success', function () {
+      interface Car {
+        name: string;
+      }
+      @Service({ id: 'cars', multiple: true })
+      class Bmw implements Car {
+        name = 'BMW';
+      }
+      @Service({ id: 'cars', multiple: true })
+      class Mercedes implements Car {
+        name = 'Mercedes';
+      }
+      @Service({ id: 'cars', multiple: true })
+      class Toyota implements Car {
+        name = 'Toyota';
+      }
+
+      const carNames = Container.getMany('cars').map(car => (car as Car).name);
+      expect(carNames).toContain('BMW');
+      expect(carNames).toContain('Mercedes');
+      expect(carNames).toContain('Toyota');
+    });
+  });
 });

--- a/test/decorators/Inject.spec.ts
+++ b/test/decorators/Inject.spec.ts
@@ -107,4 +107,78 @@ describe('Inject Decorator', function () {
     expect(instance).toBeInstanceOf(TestService);
     expect(instance.myClass).toBeInstanceOf(InjectedClass);
   });
+  it('should inject error without identifier or type', function () {
+    function demo() {
+      @Service()
+      class SecondTestService {
+        @Inject(() => undefined)
+        testService: any;
+      }
+      Container.get(SecondTestService);
+    }
+
+    expect(demo).toThrow(
+      `Cannot inject value into "SecondTestService.testService". Please make sure you setup reflect-metadata properly and you don't use interfaces without service tokens as injection value.`
+    );
+  });
+
+  it('should inject many error without identifier or type', function () {
+    function demo() {
+      interface Car {
+        name: string;
+      }
+      @Service({ id: 'cars', multiple: true })
+      class Bmw implements Car {
+        name = 'BMW';
+      }
+      @Service({ id: 'cars', multiple: true })
+      class Mercedes implements Car {
+        name = 'Mercedes';
+      }
+      @Service({ id: 'cars', multiple: true })
+      class Toyota implements Car {
+        name = 'Toyota';
+      }
+      @Service()
+      class TestServiceWithParameters {
+        constructor(@InjectMany() public cars: any) {}
+      }
+
+      Container.get(TestServiceWithParameters);
+    }
+
+    expect(demo).toThrow(
+      `Cannot inject value into \"Function.undefined\". Please make sure you setup reflect-metadata properly and you don't use interfaces without service tokens as injection value.`
+    );
+  });
+
+  it('should inject many error when identifier callback return undefined', function () {
+    function demo() {
+      interface Car {
+        name: string;
+      }
+      @Service({ id: 'cars', multiple: true })
+      class Bmw implements Car {
+        name = 'BMW';
+      }
+      @Service({ id: 'cars', multiple: true })
+      class Mercedes implements Car {
+        name = 'Mercedes';
+      }
+      @Service({ id: 'cars', multiple: true })
+      class Toyota implements Car {
+        name = 'Toyota';
+      }
+      @Service()
+      class TestServiceWithParameters {
+        constructor(@InjectMany(() => undefined) public cars: Car[]) {}
+      }
+
+      Container.get(TestServiceWithParameters);
+    }
+
+    expect(demo).toThrow(
+      `Cannot inject value into \"Function.undefined\". Please make sure you setup reflect-metadata properly and you don't use interfaces without service tokens as injection value.`
+    );
+  });
 });


### PR DESCRIPTION
## Description
Save the internal handlers and services and replace the array with map to improve performance

## Benchmark
```javascript

const Benchmark = require('benchmark');
const typedi = require('typedi');
// perf-20210707
const typedi2 = require('../typedi/build/cjs');

const suite = new Benchmark.Suite();
for (let i = 0; i < 1000; i++) {
    typedi.Container.set(i + "", i);
    typedi2.Container.set(i + "", i);
}

function getIndex() {
    return Math.floor(Math.random() * 1000);
}

// add tests
suite
    .add('typedi', function () {
        typedi.Container.get(getIndex() + "");
    })
    .add('perf-20210707', function () {
        typedi2.Container.get(getIndex() + "");
    })
    // add listeners
    .on('cycle', function (event) {
        console.log(String(event.target));
    })
    .on('complete', function () {
        console.log('Fastest is ' + this.filter('fastest').map('name'));
    })
    // run async
    .run({ 'async': true });

```
```
typedi x 137,686 ops/sec ±4.46% (75 runs sampled)
perf-20210707 x 4,944,257 ops/sec ±11.93% (61 runs sampled)
Fastest is perf-20210707
```