### PR TITLE
feat: add ability to clone a container

### DIFF
--- a/test/Container.spec.ts
+++ b/test/Container.spec.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import { Constructable, Container } from '../src/index';
+import { Constructable, Container, ContainerInstance } from '../src/index';
 import { Service } from '../src/decorators/service.decorator';
 import { Token } from '../src/token.class';
 import { ServiceNotFoundError } from '../src/error/service-not-found.error';
@@ -363,6 +363,38 @@ describe('Container', function () {
       expect(instanceA).toBeInstanceOf(MyService);
       expect(instanceB).toBeInstanceOf(MyService);
       expect(instanceA).not.toBe(instanceB);
+    });
+  });
+
+  describe('Container.clone', () => {
+    it('should be able to create a clone', () => {
+      @Service()
+      class MyServiceA {
+        valueA = 'a';
+      }
+
+      @Service()
+      class MyServiceB {
+        valueB = 'b';
+      }
+
+      const container = new ContainerInstance('Container.clone.1.1');
+      container.get(MyServiceA);
+
+      const clone = container.clone('Container.clone.1.2');
+      const serviceA1 = container.get(MyServiceA);
+      const serviceA2 = clone.get(MyServiceA);
+
+      const serviceB1 = container.get(MyServiceB);
+      const serviceB2 = clone.get(MyServiceB);
+
+      expect(serviceA1).toBeInstanceOf(MyServiceA);
+      expect(serviceA2).toBeInstanceOf(MyServiceA);
+      expect(serviceA1).toBe(serviceA2);
+
+      expect(serviceB1).toBeInstanceOf(MyServiceB);
+      expect(serviceB2).toBeInstanceOf(MyServiceB);
+      expect(serviceB1).not.toBe(serviceB2);
     });
   });
 


### PR DESCRIPTION
## Checklist
- [x] the pull request title describes what this PR does (not a vague title like `Update index.md`)
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [x] the code follows the established code style of the repository
  - `npm run prettier:check` passes
  - `npm run lint:check` passes
- [x] tests are added for the changes I made (if any source code was modified)
- [ ] documentation added or updated
- [x] I have run the project locally and verified that there are no errors

## Description
This commit adds a new `.clone(id)` function to a container, which creates a new container cloned from the previous one.

**Why?**:

An example use case and the reason that I created this addition; in an API built using fastify I want each request to have its own container, so I can set things like authorization and make it available inside my services.

```typescript
instance.decorateRequest<ContainerInstance>('container', undefined as any);

instance.addHook('preHandler', async (request) => {
  const container = new ContainerInstance(request.id);
  container.set(Auth, request.user);
  request.container = container;
});
```

but I want all services to share the same database connection manager, so I have to set it on all requests. I can do this by setting it on the global container and then re-apply it on my plugin.

```typescript
Container.set(DBClient, new DBClient(/* args */));

// ...

instance.decorateRequest<ContainerInstance>('container', undefined as any);

instance.addHook('preHandler', async (request) => {
  const container = new ContainerInstance(request.id);
  container.set(Auth, request.user);
  const dbService = Container.get(DBClient);
  container.set(dbService);
  request.container = container;
});
```

But this kind of breaks some of the fundamental ideas of DI, so what I would instead do is create a detached clone based on whatever is inside my default container (or any other specific container instance), carrying along anything that was set then.

```typescript
Container.set(DBClient, new DBClient(/* args */));

// ...

instance.decorateRequest<ContainerInstance>('container', undefined as any);

instance.addHook('preHandler', async (request) => {
  const container = Container.clone(request.id);
  container.set(Auth, request.user);
  container.set(dbService);
  request.container = container;
});
```

There are several use cases both in the application logic and mocking for tests where having a "shared" container that gets cloned and extended for specific use cases makes a lot of sense.
